### PR TITLE
Add backwards compatibility with bunch library

### DIFF
--- a/munch/__init__.py
+++ b/munch/__init__.py
@@ -24,7 +24,8 @@
 __version__ = '2.0.4'
 VERSION = tuple(map(int, __version__.split('.')))
 
-__all__ = ('Munch', 'munchify', 'unmunchify')
+__all__ = ('Munch', 'munchify', 'unmunchify',
+           'Bunch', 'bunchify', 'unbunchify')  # Backwards compatibility names
 
 from .python3_compat import *  # noqa
 
@@ -369,6 +370,13 @@ try:
 
     Munch.toYAML = toYAML
     Munch.fromYAML = staticmethod(fromYAML)
+
+
+# Backwards compatibility with original library
+
+Bunch = Munch
+bunchify = munchify
+unbunchify = unmunchify
 
 except ImportError:
     pass


### PR DESCRIPTION
For people who have "bunch" spread all over the codebase from the library, this adds the old Bunch/bunchify/unbunchify names that call Munch/munchify/unmunchify respectively. This allows having the change in code when switching to munch be restricted just to a library name change.
